### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Upstash MCP Server
+[![smithery badge](https://smithery.ai/badge/@upstash/mcp-server-upstash)](https://smithery.ai/server/@upstash/mcp-server-upstash)
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, we provide an installer as well as an MCP Server for [Upstash Developer API's](https://upstash.com/docs/devops/developer-api).
 
@@ -19,7 +20,15 @@ This lets you use Claude Desktop, or any MCP Client, to use natural language to 
 - [Upstash API key](https://upstash.com/docs/devops/developer-api) - You can create one from [here](https://console.upstash.com/account/api).
 
 ## How to use locally
+### Installing via Smithery
 
+To install Upstash for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@upstash/mcp-server-upstash):
+
+```bash
+npx -y @smithery/cli install @upstash/mcp-server-upstash --client claude
+```
+
+### Installing manually
 1. Run `npx @upstash/mcp-server-upstash init <UPSTASH_EMAIL> <UPSTASH_API_KEY>`
 2. Restart Claude Desktop
 3. You should now be able to use Upstash commands in Claude Desktop


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Upstash for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@upstash/mcp-server-upstash

Let me know if any tweaks have to be made!