### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, we provide an installer as well as an MCP Server for [Upstash Developer API's](https://upstash.com/docs/devops/developer-api).
 
+<a href="https://glama.ai/mcp/servers/4slca1893i">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/4slca1893i/badge" alt="Upstash Server MCP server" />
+</a>
+
 This lets you use Claude Desktop, or any MCP Client, to use natural language to accomplish things on your Upstash account, e.g.:
 
 - "Create a new Redis database in us-east-1"


### PR DESCRIPTION
This PR adds a badge for the [Upstash MCP Server](https://glama.ai/mcp/servers/4slca1893i) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4slca1893i">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/4slca1893i/badge" alt="Upstash Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.