### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "upstash-mcp",
+  "description": "MCP server for managing & debugging Upstash Redis, QStash, Workflow and Box",
+  "author": {
+    "name": "Upstash",
+    "email": "support@upstash.com"
+  },
+  "homepage": "https://upstash.com",
+  "repository": "https://github.com/upstash/mcp-server",
+  "license": "MIT",
+  "keywords": ["upstash", "redis", "qstash", "workflow", "database", "serverless"],
+  "category": "integration",
+  "userConfig": {
+    "email": {
+      "title": "Email",
+      "description": "Your Upstash account email",
+      "type": "string",
+      "sensitive": false
+    },
+    "api_key": {
+      "title": "API Key",
+      "description": "Your Upstash API key (from console.upstash.com/account/api)",
+      "type": "string",
+      "sensitive": true
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "upstash": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/mcp-server@latest",
+        "--email",
+        "${user_config.email}",
+        "--api-key",
+        "${user_config.api_key}"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` with `userConfig` for credential prompting (email + API key)
- Adds `.mcp.json` for MCP server configuration via `${user_config.*}` substitution
- API key is stored securely in the OS keychain (`sensitive: true`)

This enables installation via the Claude Code plugin system. A companion PR to `upstash/skills` adds the marketplace entry pointing to this repo.